### PR TITLE
ENH: Add ITK PCA example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+examples/.ipynb_checkpoints
+examples/data

--- a/examples/ITKPCATransformInitialization.ipynb
+++ b/examples/ITKPCATransformInitialization.ipynb
@@ -1,0 +1,198 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# ITK PCA-Based Transform Initialization\n",
+    "\n",
+    "The SlicerMorph registration pipeline takes place in three steps:\n",
+    "    - Initialization: Meshes are roughly aligned to the same space\n",
+    "    - Rigid registration: Meshes are closely aligned without deformation via ICP\n",
+    "    - Deformable registration: Meshes are deformed to match with the Thin Shells Demon algorithm\n",
+    "    \n",
+    "This notebook demonstrates one way in which existing ITK filters may be leveraged to get a \"close enough\" mesh initialization result. Principal components are computed with an image approximation of each mesh and subsequently employed to axis-align the two meshes.\n",
+    "\n",
+    "One pitfall is that PCA may fail to align the meshes if they start with opposing orientation. Moment-based initialization should be further investigated to overcome this failure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import itk\n",
+    "import vtk\n",
+    "import itkwidgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "FIXED_MESH_FILE = r'data/129S1_SVIMJ_.ply'\n",
+    "MOVING_MESH_FILE = r'data/129X1_SVJ_.ply'\n",
+    "paths = [FIXED_MESH_FILE, MOVING_MESH_FILE]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import importlib\n",
+    "from urllib.request import urlretrieve\n",
+    "\n",
+    "# Download meshes\n",
+    "os.makedirs('data',exist_ok=True)\n",
+    "if not os.path.exists(FIXED_MESH_FILE):\n",
+    "    url = 'https://github.com/SlicerMorph/Mouse_Models/raw/main/Models/129S1_SVIMJ_.ply'\n",
+    "    urlretrieve(url, FIXED_MESH_FILE)\n",
+    "if not os.path.exists(MOVING_MESH_FILE):\n",
+    "    url = 'https://github.com/SlicerMorph/Mouse_Models/raw/main/Models/129X1_SVJ_.ply'\n",
+    "    urlretrieve(url, MOVING_MESH_FILE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vtk_meshes = list()\n",
+    "\n",
+    "for path in paths:\n",
+    "    reader = vtk.vtkPLYReader()\n",
+    "    reader.SetFileName(path)\n",
+    "    reader.Update()\n",
+    "    vtk_meshes.append(reader.GetOutput())\n",
+    "    \n",
+    "# Write back out to a filetype supported by ITK\n",
+    "vtk_paths = [path.strip('.ply') + '.obj' for path in paths]\n",
+    "for idx, mesh in enumerate(vtk_meshes):\n",
+    "    writer = vtk.vtkOBJWriter()\n",
+    "    writer.SetInputData(mesh)\n",
+    "    writer.SetFileName(vtk_paths[idx])\n",
+    "    writer.Update()\n",
+    "    \n",
+    "itk_meshes = [itk.meshread(path,pixel_type=itk.UC) for path in vtk_paths]\n",
+    "\n",
+    "view = itkwidgets.view(geometries=[x for x in itk_meshes])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "itk_images = [itk.triangle_mesh_to_binary_image_filter(mesh,\n",
+    "                                                       origin=[0,0,0],\n",
+    "                                                       spacing=[0.5,0.5,0.5],\n",
+    "                                                       size=[50,50,50])\n",
+    "              for mesh in itk_meshes]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6b7f18c991d84cdaa84d7f8f352539f1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(Viewer(annotations=False, interpolation=False, rendered_image=<itk.itkImagePython.itkImageUC3; …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "itkwidgets.checkerboard(*itk_images)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "itk_transforms = list()\n",
+    "\n",
+    "for image in itk_images:\n",
+    "    calculator = itk.ImageMomentsCalculator[type(image)].New()\n",
+    "    calculator.SetImage(image)\n",
+    "    calculator.Compute()\n",
+    "    itk_transforms.append(calculator.GetPhysicalAxesToPrincipalAxesTransform())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "itk_transformed_meshes = [\n",
+    "    itk.transform_mesh_filter(mesh, transform=itk_transforms[idx])\n",
+    "    for idx, mesh in enumerate(itk_meshes)\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "18e98795c02145378ceb502acf6d6630",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Viewer(geometries=[{'vtkClass': 'vtkPolyData', 'points': {'vtkClass': 'vtkPoints', 'numberOfComponents': 3, 'd…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "itkwidgets.view(geometries=itk_transformed_meshes)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv-itk",
+   "language": "python",
+   "name": "venv-itk"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Small example demonstrating registration initialization with ITK image PCA computation.

Currently investigating extending the moments calculations done by the `itk::ImageMomentsCalculator` object used in this demo so that it can be used in point set initialization and for overcoming PCA symmetry pitfalls.